### PR TITLE
docs: document Hermit appeal forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It's written from the perspective of myself and the other leads, but is open sou
 This is a living document, anything can and will be changed at any time without warning. The only exception is the Rules, which will have changes announced in the #announcements channel within the server.
 If you think that something should be changed in our policies, feel free to open a GitHub issue here on this repo.
 
-**This repository is not the place to appeal moderation actions or report a moderator. This is solely to house and discuss our policies.** If you want to appeal a moderation action or report a moderator, please go to https://appeal.gg/clawd and submit the form there.
+**This repository is not the place to appeal moderation actions or report a moderator. This is solely to house and discuss our policies.** If you want to appeal a moderation action or report a moderator, use the forms at https://appeal.openclaw.ai.
 
 # Table of Contents
 
@@ -13,6 +13,7 @@ If you think that something should be changed in our policies, feel free to open
 - [Rules (Mirror)](rules.md)
 - [Roles Reference](roles.md)
 - [Incident Playbook](incident-playbook.md)
+- [Appeals and Moderator Reports](appeals-and-reports.md)
 - [Bot Reference](bot-management.md)
 
 # Community Staff Structure

--- a/appeals-and-reports.md
+++ b/appeals-and-reports.md
@@ -13,14 +13,16 @@ Both hosts are first-class. Neither host is a legacy alias.
 
 | Form | Path | Auth options | Review channel |
 | --- | --- | --- | --- |
-| Discord appeal | `/discord` | Discord | `#cs-appeals` |
+| Discord ban appeal | `/discord-ban` | Discord | `#cs-appeals` |
+| Discord mute appeal | `/discord-mute` | Discord | `#cs-appeals` |
 | GitHub appeal | `/github` | GitHub | `#cs-appeals` |
 | Reddit appeal | `/reddit` | Reddit | `#cs-appeals` |
 | Report a Moderator | `/report-mod` | Discord, GitHub, or Reddit | `#shadow` |
 
 Use these links when directing users:
 
-- Discord appeal: https://appeal.openclaw.ai/discord
+- Discord ban appeal: https://appeal.openclaw.ai/discord-ban
+- Discord mute appeal: https://appeal.openclaw.ai/discord-mute
 - GitHub appeal: https://appeal.openclaw.ai/github
 - Reddit appeal: https://appeal.openclaw.ai/reddit
 - Report a moderator: https://appeal.openclaw.ai/report-mod
@@ -57,7 +59,8 @@ Review cards appear in `#cs-appeals`. Use the buttons on the review card:
 
 Configured accept actions:
 
-- Discord appeal: removes the active timeout or unbans the user, depending on the moderation context Hermit found.
+- Discord ban appeal: unbans the user.
+- Discord mute appeal: removes the active timeout.
 - GitHub appeal: unblocks the user from the OpenClaw GitHub organization.
 - Reddit appeal: asks the Devvit Reddit bridge to unban the user from `r/openclaw`, then updates Hermit's stored Reddit moderation context.
 

--- a/appeals-and-reports.md
+++ b/appeals-and-reports.md
@@ -1,0 +1,84 @@
+# Appeals and Moderator Reports
+
+OpenClaw uses Hermit Forms for moderation appeals and moderator reports.
+
+Primary forms hosts:
+
+- https://appeal.openclaw.ai
+- https://forms.openclaw.ai
+
+Both hosts are first-class. Neither host is a legacy alias.
+
+## User-facing forms
+
+| Form | Path | Auth options | Review channel |
+| --- | --- | --- | --- |
+| Discord appeal | `/discord` | Discord | `#cs-appeals` |
+| GitHub appeal | `/github` | GitHub | `#cs-appeals` |
+| Reddit appeal | `/reddit` | Reddit | `#cs-appeals` |
+| Report a Moderator | `/report-mod` | Discord, GitHub, or Reddit | `#shadow` |
+
+Use these links when directing users:
+
+- Discord appeal: https://appeal.openclaw.ai/discord
+- GitHub appeal: https://appeal.openclaw.ai/github
+- Reddit appeal: https://appeal.openclaw.ai/reddit
+- Report a moderator: https://appeal.openclaw.ai/report-mod
+
+## Appeal flow
+
+```mermaid
+flowchart TD
+  U[User opens appeal.openclaw.ai] --> F{Choose form}
+  F --> D[Discord appeal]
+  F --> G[GitHub appeal]
+  F --> R[Reddit appeal]
+  D --> DA[Sign in with Discord]
+  G --> GA[Sign in with GitHub]
+  R --> RA[Sign in with Reddit]
+  DA --> C[Hermit adds moderation context]
+  GA --> C
+  RA --> C
+  C --> Q[User answers form questions]
+  Q --> M[Hermit posts review card]
+  M --> A{Staff decision}
+  A -->|Accept| X[Hermit runs configured action]
+  A -->|Deny| Y[Hermit records decision]
+```
+
+## How staff should review appeals
+
+Appeals should be handled by someone other than the moderator who issued the action. If you issued the original action, ask another moderator, lead, or the Admin to handle the appeal.
+
+Review cards appear in `#cs-appeals`. Use the buttons on the review card:
+
+- **Accept**: records the appeal as accepted and runs the configured action.
+- **Deny**: records the appeal as denied.
+
+Configured accept actions:
+
+- Discord appeal: removes the active timeout or unbans the user, depending on the moderation context Hermit found.
+- GitHub appeal: unblocks the user from the OpenClaw GitHub organization.
+- Reddit appeal: asks the Devvit Reddit bridge to unban the user from `r/openclaw`, then updates Hermit's stored Reddit moderation context.
+
+Deny does not run an external action.
+
+## Report a Moderator flow
+
+Reports against moderators go to `#shadow`, not `#cs-appeals`.
+
+The report form asks:
+
+- who is being reported,
+- why they are being reported,
+- confirmation that the reporter understands false reports may result in punishment.
+
+Users may authenticate with Discord, GitHub, or Reddit for this form. Reports should be handled by the Admin or a specifically delegated lead.
+
+## Reddit moderation context
+
+Reddit appeals use Reddit OAuth for identity only. Hermit does not hold Reddit moderator OAuth tokens.
+
+Reddit moderation context is supplied by a Devvit app installed for `r/openclaw`. The Devvit app sends Hermit the current moderation context for a Reddit user, including whether they are banned and the listed reason when available.
+
+The Devvit bridge is also responsible for executing Reddit unban actions when a Reddit appeal is accepted.

--- a/bot-management.md
+++ b/bot-management.md
@@ -13,7 +13,7 @@ Used for SEO and #help management
 https://answeroverflow.com
 
 ## Barnacle
-Whitelabel bot of https://sapph.xyz and https://appeal.gg, used for all moderation and appeals management (Sapphire instance)
+Whitelabel bot of https://sapph.xyz, used for Discord moderation commands and moderation records.
 
 ## Audrey
 Used for automod in voice channels, especially for soundboard spam and VC trolling, and the /report-vc command
@@ -55,9 +55,33 @@ Gateway forwarder:
 
 The old in-Worker Cloudflare Gateway Durable Object setup is no longer the active gateway path. Gateway events now come through the external forwarder.
 
+### Hermit Forms
+
+Hermit runs the OpenClaw forms site for appeals and moderator reports.
+
+Forms hosts:
+
+- https://appeal.openclaw.ai
+- https://forms.openclaw.ai
+
+Both hosts are first-class. `appeal.openclaw.ai` is not a legacy alias.
+
+Forms configuration lives in Hermit's root `forms.config.ts`. That file is the source of truth for form IDs, copy, review channels, and accept/deny actions.
+
+Current forms:
+
+| Form | Path | Review channel |
+| --- | --- | --- |
+| Discord appeal | `/discord` | `#cs-appeals` |
+| GitHub appeal | `/github` | `#cs-appeals` |
+| Reddit appeal | `/reddit` | `#cs-appeals` |
+| Report a Moderator | `/report-mod` | `#shadow` |
+
+Reddit moderation context and Reddit unban actions are handled through a Devvit bridge. Hermit uses Reddit OAuth for identity, but does not store Reddit moderator OAuth tokens.
+
 ### Hermit D1 and deploy setup
 
-Hermit uses Cloudflare D1 for persistent bot state, including clawtributor claim dedupe and other operational records. Drizzle owns the TypeScript schema and generates SQL migration files in the repo; Wrangler applies those migrations to the Cloudflare D1 database.
+Hermit uses Cloudflare D1 for persistent bot state, including clawtributor claim dedupe, Forms submissions, Reddit moderation context, and other operational records. Drizzle owns the TypeScript schema and generates SQL migration files in the repo; Wrangler applies those migrations to the Cloudflare D1 database.
 
 Relevant repo paths:
 

--- a/bot-management.md
+++ b/bot-management.md
@@ -72,7 +72,8 @@ Current forms:
 
 | Form | Path | Review channel |
 | --- | --- | --- |
-| Discord appeal | `/discord` | `#cs-appeals` |
+| Discord ban appeal | `/discord-ban` | `#cs-appeals` |
+| Discord mute appeal | `/discord-mute` | `#cs-appeals` |
 | GitHub appeal | `/github` | `#cs-appeals` |
 | Reddit appeal | `/reddit` | `#cs-appeals` |
 | Report a Moderator | `/report-mod` | `#shadow` |

--- a/moderation.md
+++ b/moderation.md
@@ -23,17 +23,22 @@ When you're moderating, please keep in mind that the user can see everything you
 
 Some users here have access to moderate users on Github, maintainers or community staff can ping them for situations on Github in #github-moderation, and full guidelines are there.
 
-## Appeals
+## Appeals and Moderator Reports
 
-Users can appeal their mutes and bans by going to https://appeal.gg/clawd.
+Users can appeal mutes and bans or report a moderator at https://appeal.openclaw.ai.
 
-Community Staff can review these either in the #appeal channel or by going to https://dashboard.appeal.gg/1456350064065904867/submissions
+Current form links:
 
-They can also report you to admins on that same form.
+- Discord appeal: https://appeal.openclaw.ai/discord
+- GitHub appeal: https://appeal.openclaw.ai/github
+- Reddit appeal: https://appeal.openclaw.ai/reddit
+- Report a moderator: https://appeal.openclaw.ai/report-mod
 
-Appeals should be handled by someone other than the originating mod. If you issued the action, do not review that appeal, ask another mod or your lead/admin to handle it.
+Community Staff review appeals in `#cs-appeals`. Moderator reports go to `#shadow` and should be handled by the Admin or a specifically delegated lead.
 
-When you accept or deny the appeal, the user will see the reason you put in, in the format like `Your appeal was accepted. ${reason}`
+Appeals should be handled by someone other than the originating mod. If you issued the action, do not review that appeal; ask another mod, your lead, or the Admin to handle it.
+
+See [Appeals and Moderator Reports](appeals-and-reports.md) for the full flow.
 
 ## Working in Chat
 

--- a/moderation.md
+++ b/moderation.md
@@ -29,7 +29,8 @@ Users can appeal mutes and bans or report a moderator at https://appeal.openclaw
 
 Current form links:
 
-- Discord appeal: https://appeal.openclaw.ai/discord
+- Discord ban appeal: https://appeal.openclaw.ai/discord-ban
+- Discord mute appeal: https://appeal.openclaw.ai/discord-mute
 - GitHub appeal: https://appeal.openclaw.ai/github
 - Reddit appeal: https://appeal.openclaw.ai/reddit
 - Report a moderator: https://appeal.openclaw.ai/report-mod

--- a/roles.md
+++ b/roles.md
@@ -14,4 +14,4 @@ Members claim this themselves with Hermit's `/claim` command. Hermit gathers the
 
 Shell Society gives users access to the Shell Society.
 
-The application is at https://appeal.gg/clawd alongside regular appeals. These go to the Admin.
+The application process is handled by the Admin. Do not use the appeals forms for Shell Society requests unless the Admin specifically directs someone there.


### PR DESCRIPTION
## Summary
- document Hermit Forms as the OpenClaw appeals and moderator-report system
- update moderation docs from appeal.gg to appeal.openclaw.ai form paths
- document first-class forms hosts, review channels, Devvit Reddit bridge, and Hermit Forms operations

## Testing
- docs-only; not run
