### PR TITLE
claw slop

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ These are not areas of responsibility or separate teams. They are extra permissi
 - Use #github-moderation for coordination.
 - This is an elevated permission group, not a separate staff area.
 
+Current GitHub Moderator:
+
+- Hannes Rudolph (`@hannesrudolph`)
+
 ## Backup Discord Server
 
 The backup Discord server remains available at https://discord.gg/openclaw.

--- a/helpers/krill.md
+++ b/helpers/krill.md
@@ -1,14 +1,5 @@
 Krill is the OpenClaw instance that functions as our support bot in #help and #ideas. It is hosted on Julian's Hetzner instance. It is responsible for answering support questions in #help automatically, with the full context of the docs and the codebase.
 
-## Ownership and Operations
-
-- **Community responsibility:** The Help Lead coordinates Krill's community-facing use and support workflow.
-- **Current Help Lead:** Julian Engel.
-- **Hosting:** Krill runs on Julian's Hetzner instance.
-- **Escalation:** For operational assistance or an outage, ping Shadow.
-
-These notes describe Krill's operational ownership and escalation path; they do not imply that the support bot's underlying code is maintained in this repository.
-
 Community Staff can ping Krill in any channel when it would help with support, triage, or member guidance. This access is for helping the community, not for casual bot chat or off-topic use.
 
 If you need assistance with it, or it goes offline, directly ping Shadow.

--- a/helpers/krill.md
+++ b/helpers/krill.md
@@ -1,5 +1,14 @@
 Krill is the OpenClaw instance that functions as our support bot in #help and #ideas. It is hosted on Julian's Hetzner instance. It is responsible for answering support questions in #help automatically, with the full context of the docs and the codebase.
 
+## Ownership and Operations
+
+- **Community responsibility:** The Help Lead coordinates Krill's community-facing use and support workflow.
+- **Current Help Lead:** Julian Engel.
+- **Hosting:** Krill runs on Julian's Hetzner instance.
+- **Escalation:** For operational assistance or an outage, ping Shadow.
+
+These notes describe Krill's operational ownership and escalation path; they do not imply that the support bot's underlying code is maintained in this repository.
+
 Community Staff can ping Krill in any channel when it would help with support, triage, or member guidance. This access is for helping the community, not for casual bot chat or off-topic use.
 
 If you need assistance with it, or it goes offline, directly ping Shadow.


### PR DESCRIPTION
Add Hannes Rudolph (`@hannesrudolph`) to the GitHub Moderators list in `README.md`.

This is the requested maintainer/access-list change for `openclaw/community`; no Krill documentation changes are included.