### PR TITLE
[codex] Improve Discord guide spacing

### DIFF
--- a/discord.md
+++ b/discord.md
@@ -1,19 +1,15 @@
 **Community Team Guide**
 
-**Mission**
-
 We help people use and contribute to OpenClaw.
 
-Our priorities:
-
+**Priorities**
 - Help users understand OpenClaw and solve problems.
 - Welcome members and encourage useful contribution.
 - Share accurate feature, fix, and release information.
 
 We serve the community, not bureaucracy.
 
-**Engagement**
-
+**How we engage**
 - Be helpful, patient, and respectful.
 - Give people the benefit of the doubt.
 - Treat beginner questions as chances to help.
@@ -22,29 +18,21 @@ We serve the community, not bureaucracy.
 - Banter is welcome; personal attacks, harassment, and toxic arguments are not.
 
 **Moderation**
-
 Moderation should be **light, consistent, and user-focused**. Act quickly on scams, doxxing, threats, harassment, and immediate risks.
-
 When handling an issue:
-
 1. Understand before reacting.
 2. Explain or redirect accidental issues.
 3. Use a DM when appropriate.
 4. Escalate serious or repeated malicious behavior.
 5. Document important decisions.
-
 Protect the community. Do not spend disproportionate time arguing with disruptors.
 
 **Social media**
-
 Do not get dragged into toxic arguments. Keep the focus on OpenClaw and its users. Own mistakes, correct them, and move forward.
 
 **References**
-
 [Community repo](https://github.com/openclaw/community) | [Full guide](https://github.com/openclaw/community/blob/main/README.md)
-
 [Onboarding](https://github.com/openclaw/community/blob/main/onboarding.md) | [Moderation](https://github.com/openclaw/community/blob/main/moderation.md) | [Incident playbook](https://github.com/openclaw/community/blob/main/incident-playbook.md)
-
 [Krill guide](https://github.com/openclaw/community/blob/main/helpers/krill.md)
 
 **Help users. Protect the community. Keep the project moving.**


### PR DESCRIPTION
## Summary

Adjust the Discord-ready community guide so sections are visually separated without adding blank lines inside lists or numbered guidance.

## Validation

- `git diff --check`
- Confirmed `discord.md` is 1,769 characters.
- Confirmed the branch is based on the merged `main` state.